### PR TITLE
Bump nodejs from v16 to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: false
     default: 3.9
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Tested using `act`:
<img width="964" alt="Screenshot 2024-02-08 at 15 51 55" src="https://github.com/humaans/setup-kapitan-action/assets/60406072/8f47683e-9f20-4dca-8c99-bda2937125de">
<img width="884" alt="Screenshot 2024-02-08 at 15 52 06" src="https://github.com/humaans/setup-kapitan-action/assets/60406072/9e4be770-e4c9-4349-8bc0-a899ae385533">

~There's a lot of changes once I run `npm install` but I guess it's not needed to commit?~ Ah... of course I should just run `pnpm install`